### PR TITLE
Add delete match confirmation

### DIFF
--- a/vr_score_keeper/vr_tournaments/templates/tournament_detail.html
+++ b/vr_score_keeper/vr_tournaments/templates/tournament_detail.html
@@ -21,7 +21,7 @@
                     {% for match in matches %}
                         <tr>
                             <td>
-                                <form action="{% url 'delete_match' match.pk %}" method="post">
+                                <form action="{% url 'delete_match' match.pk %}" method="post" onsubmit="return confirm('Are you sure you want to delete this match?');">
                                     {% csrf_token %}
                                     <button class="button is-danger is-dark is-small is-outlined" type="submit">{{ match.date|date:"m/d/y" }}</button>
                                 </form>

--- a/vr_score_keeper/vr_tournaments/templates/tournament_detail.html
+++ b/vr_score_keeper/vr_tournaments/templates/tournament_detail.html
@@ -21,9 +21,14 @@
                     {% for match in matches %}
                         <tr>
                             <td>
-                                <form id="form-{{ match.pk }}" action="{% url 'delete_match' match.pk %}" method="post">
+                                <form id="form-{{ match.pk }}"
+                                      action="{% url 'delete_match' match.pk %}"
+                                      method="post">
                                     {% csrf_token %}
-                                    <button class="button is-danger is-dark is-small is-outlined js-modal-trigger" type="button" data-target="delete-modal" data-form-id="form-{{ match.pk }}">{{ match.date|date:"m/d/y" }}</button>
+                                    <button class="button is-danger is-dark is-small is-outlined js-modal-trigger"
+                                            type="button"
+                                            data-target="delete-modal"
+                                            data-form-id="form-{{ match.pk }}">{{ match.date|date:"m/d/y" }}</button>
                                 </form>
                             </td>
                             {% for player in registered_players %}
@@ -71,14 +76,15 @@
         <div class="modal-card">
             <header class="modal-card-head">
                 <p class="modal-card-title">Delete Match</p>
-                <button class="delete" aria-label="close"></button>
             </header>
             <section class="modal-card-body">
                 Are you sure you want to delete this match?
             </section>
             <footer class="modal-card-foot">
-                <button id="delete-confirm-button" class="button is-danger">Delete</button>
-                <button class="button cancel-button">Cancel</button>
+                <div class="buttons">
+                    <button id="delete-confirm-button" class="button is-danger">Delete</button>
+                    <button class="button cancel-button">Cancel</button>
+                </div>
             </footer>
         </div>
     </div>

--- a/vr_score_keeper/vr_tournaments/templates/tournament_detail.html
+++ b/vr_score_keeper/vr_tournaments/templates/tournament_detail.html
@@ -21,9 +21,9 @@
                     {% for match in matches %}
                         <tr>
                             <td>
-                                <form action="{% url 'delete_match' match.pk %}" method="post" onsubmit="return confirm('Are you sure you want to delete this match?');">
+                                <form id="form-{{ match.pk }}" action="{% url 'delete_match' match.pk %}" method="post">
                                     {% csrf_token %}
-                                    <button class="button is-danger is-dark is-small is-outlined" type="submit">{{ match.date|date:"m/d/y" }}</button>
+                                    <button class="button is-danger is-dark is-small is-outlined js-modal-trigger" type="button" data-target="delete-modal" data-form-id="form-{{ match.pk }}">{{ match.date|date:"m/d/y" }}</button>
                                 </form>
                             </td>
                             {% for player in registered_players %}
@@ -65,4 +65,76 @@
         {% csrf_token %}
         <button type="submit" class="button is-danger is-outlined">DELETE</button>
     </form>
+
+    <div id="delete-modal" class="modal">
+        <div class="modal-background"></div>
+        <div class="modal-card">
+            <header class="modal-card-head">
+                <p class="modal-card-title">Delete Match</p>
+                <button class="delete" aria-label="close"></button>
+            </header>
+            <section class="modal-card-body">
+                Are you sure you want to delete this match?
+            </section>
+            <footer class="modal-card-foot">
+                <button id="delete-confirm-button" class="button is-danger">Delete</button>
+                <button class="button cancel-button">Cancel</button>
+            </footer>
+        </div>
+    </div>
+
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            let formIdToSubmit = null;
+
+            // Functions to open and close a modal
+            function openModal($el) {
+                $el.classList.add('is-active');
+            }
+
+            function closeModal($el) {
+                $el.classList.remove('is-active');
+            }
+
+            function closeAllModals() {
+                (document.querySelectorAll('.modal') || []).forEach(($modal) => {
+                    closeModal($modal);
+                });
+            }
+
+            // Add a click event on buttons to open a specific modal
+            (document.querySelectorAll('.js-modal-trigger') || []).forEach(($trigger) => {
+                const modalId = $trigger.dataset.target;
+                const $target = document.getElementById(modalId);
+
+                $trigger.addEventListener('click', () => {
+                    formIdToSubmit = $trigger.dataset.formId;
+                    openModal($target);
+                });
+            });
+
+            // Add a click event on various child elements to close the parent modal
+            (document.querySelectorAll('.modal-background, .modal-close, .modal-card-head .delete, .cancel-button') || []).forEach(($close) => {
+                const $target = $close.closest('.modal');
+
+                $close.addEventListener('click', () => {
+                    closeModal($target);
+                });
+            });
+
+            // Add a keyboard event to close all modals
+            document.addEventListener('keydown', (event) => {
+                if (event.key === "Escape") {
+                    closeAllModals();
+                }
+            });
+
+            // Add a click event to the confirm delete button
+            document.getElementById('delete-confirm-button').addEventListener('click', () => {
+                if (formIdToSubmit) {
+                    document.getElementById(formIdToSubmit).submit();
+                }
+            });
+        });
+    </script>
 {% endblock content %}


### PR DESCRIPTION
This pull request enhances the user experience by adding a crucial confirmation step before a match can be deleted. The change introduces a modal dialog that prompts the user to confirm their intention, thereby safeguarding against unintended deletions.

### Highlights

* **User Experience Improvement**: Implemented a confirmation modal for deleting matches, preventing accidental data loss and improving the user experience.
* **Frontend Logic**: Modified the match deletion button to trigger a modal instead of directly submitting the form, and added JavaScript to handle the modal's display and the delayed form submission upon user confirmation.
* **New UI Component**: Introduced a new modal structure in the `tournament_detail.html` template to serve as the confirmation dialog.